### PR TITLE
Update to .NET 4.8 and Newtonsoft.Json 13.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+#Custom folder
+_Notes
+
 # User-specific files
 *.rsuser
 *.suo
@@ -348,3 +351,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+/KobberLan/.idea

--- a/KobberLan/KobberLan.csproj
+++ b/KobberLan/KobberLan.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>KobberLan</RootNamespace>
     <AssemblyName>KobberLan</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -49,8 +49,8 @@
     <Reference Include="MonoTorrent, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\MonoTorrent.1.0.28\lib\netstandard2.0\MonoTorrent.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.13.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="ReusableTasks, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\ReusableTasks.2.0.0\lib\netstandard2.0\ReusableTasks.dll</HintPath>

--- a/KobberLan/packages.config
+++ b/KobberLan/packages.config
@@ -4,7 +4,7 @@
   <package id="Desharp" version="1.3.0.3" targetFramework="net472" />
   <package id="Mono.Nat" version="3.0.1" targetFramework="net472" />
   <package id="MonoTorrent" version="1.0.28" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net472" />
   <package id="ReusableTasks" version="2.0.0" targetFramework="net472" />
   <package id="System.ServiceModel.Primitives" version="4.8.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Upgraded KobberLan project to target .NET Framework 4.8 and updated the Newtonsoft.Json dependency to version 13.0.4. Also updated .gitignore to exclude custom folders and IDE files.